### PR TITLE
clr-power-rfkill: add a bluetooth block service

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = clr_power
 clr_power_SOURCES = src/main.c src/lib.c src/pci.c src/ethernet.c src/usb.c src/gfx.c src/verifytime.c generated.c
 
-systemdsystemunit_DATA = clr-power.service clr-power.timer
+systemdsystemunit_DATA = clr-power.service clr-power.timer clr-power-rfkill.service
 
 generated.c: clr-power-tweaks.conf $(top_srcdir)/generate-tweaks.pl
 	$(top_srcdir)/generate-tweaks.pl $< > $@

--- a/clr-power-rfkill.service
+++ b/clr-power-rfkill.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Rfkill bluetooth controllers on first boot
+After=sysinit.target
+ConditionFileIsExecutable=/usr/bin/rfkill
+ConditionFirstBoot=true
+ConditionVirtualization=!container
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/rfkill block bluetooth


### PR DESCRIPTION
On first boot of a Clear Linux system, "soft block" all bluetooth
controllers on the system. This enforces a 'powered off by default'
policy for fresh Clear Linux installations. On at least one reference
platform, an unblocked controller will prevent that platform from idling
deeply because BlueZ will keep managed controllers in a "always powered
on" state, irrespective of device activity.

Work around limitations within the bluetooth ecosystem-- BlueZ and
friends-- which offers no out-of-box config facilities to change
"powered on/off" default behaviors for bluetooth controllers.

Until BlueZ gets more granular configuration facilities added, this will
have to do for Clear Linux.

Signed-off-by: Joe Konno <joe.konno@intel.com>