### PR TITLE
Update clr-power-rfkill.service

### DIFF
--- a/clr-power-rfkill.service
+++ b/clr-power-rfkill.service
@@ -2,6 +2,7 @@
 Description=Rfkill bluetooth controllers on first boot
 After=sysinit.target
 ConditionFileIsExecutable=/usr/bin/rfkill
+ConditionPathExists=/dev/rfkill
 ConditionFirstBoot=true
 ConditionVirtualization=!container
 


### PR DESCRIPTION
prevent that the service logs failures on configs not having RFKILL enabled, e.g. linux-kvm