### PR TITLE
Add desktop vs. server specific tweaking.

### DIFF
--- a/clr_power.1
+++ b/clr_power.1
@@ -1,7 +1,0 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "CLR_POWER" "1" "February 2020" "" ""
-.
-.SH "NAME"
-\fBclr_power\fR

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_CHECK_HEADER_STDBOOL
 AC_TYPE_SIZE_T
 
 # Checks for library functions.
-AC_CHECK_FUNCS([memset socket strdup strerror strtoul strtoull clock_gettime])
+AC_CHECK_FUNCS([memset socket strstr strdup strerror strtoul strtoull clock_gettime])
 
 
 AC_CONFIG_HEADERS([config.h])

--- a/man/clr-power-tweaks.conf.5
+++ b/man/clr-power-tweaks.conf.5
@@ -1,0 +1,96 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "CLR\-POWER\-TWEAKS" "5" "March 2020" "" ""
+.
+.SH "NAME"
+\fBclr\-power\-tweaks\fR
+.
+.SH "SYNOPSIS"
+\fB\fBclr\-power\-tweaks\.conf\fR\fR is an optional configuration file for the clr_power(1) utility\.
+.
+.P
+\fB/etc/clr\-power\-tweaks\.conf\fR
+.
+.SH "DESCRIPTION"
+\fB\fBclr\-power\-tweaks\.conf\fR\fR is an optional configuration file for the clr_power(1) utility\. The configuration file contains kernel and device parameter values used by the clr_power(1) utility\.
+.
+.P
+Configuration parameter values placed in \fB\fBclr\-power\-tweaks\.conf\fR\fR will supersede the built\-in defaults configured by clr_power(1)\. New parameters can be added to the configuration to supplement the built\-in values\. Built\-in parameters can be changed by defining them in \fB\fBclr\-power\-tweaks\.conf\fR\fR with a different value\. Parameters can be excluded from being modified by clr_power(1) by adding them in \fB\fBclr\-power\-tweaks\.conf\fR\fR without a value\.
+.
+.SH "FILE FORMAT"
+\fB\fBclr\-power\-tweaks\.conf\fR\fR uses a key\-value pairs to define parameter values\.
+.
+.P
+Each line contains one parameter\-value pair, delimited by a space character\.
+.
+.P
+Parameters are paths from the proc(5) filesystem\. Parameters paths can include glob(n) wildcards to match multiple paths\.
+.
+.P
+Acceptable values are determined by the parameter being set\. Any parameter listed in the configuration file without a value will be excluded by clr_power(1) and the parameter will inherit the kernel\'s built\-in default parameter value\.
+.
+.SH "EXAMPLES"
+.
+.IP "1." 4
+\fB\fBclr\-power\-tweaks\.conf\fR\fR entry to override the default value in clr_power(1) for CPU governor with \fBpowersave\fR\. All other values built\-in to clr_power(1) would still get applied\.
+.
+.IP
+Note the globbing used with \fB*\fR to target all CPU cores\.
+.
+.IP "" 4
+.
+.nf
+
+/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor powersave
+.
+.fi
+.
+.IP "" 0
+
+.
+.IP "2." 4
+\fB\fBclr\-power\-tweaks\.conf\fR\fR entry to exclude a parameter causing it to use the kernel\'s built\-in default value (60)\. All other values built\-in to clr_power(1) would still get applied\.
+.
+.IP
+Note the omission of a value\.
+.
+.IP "" 4
+.
+.nf
+
+/proc/sys/vm/swappiness
+.
+.fi
+.
+.IP "" 0
+
+.
+.IP "3." 4
+\fB\fBclr\-power\-tweaks\.conf\fR\fR entry to add two new parameters to increase UDP buffers All other values built\-in to clr_power(1) would still get applied\.
+.
+.IP "" 4
+.
+.nf
+
+/proc/sys/net/ipv4/udp_rmem_min 8192
+/proc/sys/net/ipv4/udp_wmem_min 8192
+.
+.fi
+.
+.IP "" 0
+
+.
+.IP "" 0
+.
+.SH "BUGS"
+The default clr\-power\-tweaks\.conf(5) aims to have reasonable defaults for achieving power and performance efficiency\. Default values may not be optimal for all systems and environments\.
+.
+.P
+See GitHub Issues: \fIhttps://github\.com/clearlinux/clr\-power\-tweaks/issues\fR
+.
+.SH "SEE ALSO"
+\fBclr_power\.conf(5)\fR, \fBproc(5)\fR, \fBsysctl(2)\fR
+.
+.P
+For parameters understood by the kernel, please see https://www\.kernel\.org/doc/html/latest/admin\-guide/kernel\-parameters\.html

--- a/man/clr_power.1
+++ b/man/clr_power.1
@@ -1,0 +1,56 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "CLR_POWER" "1" "March 2020" "" ""
+.
+.SH "NAME"
+\fBclr_power\fR
+.
+.SH "SYNOPSIS"
+\fB\fBclr_power\fR\fR is a utility to adjust power and performance settings in the operating system\. It is configurable and can enforce power and performance policies\.
+.
+.P
+\fBclr_power\fR [\fB\-d\fR|\fB\-\-debug\fR]
+.
+.SH "DESCRIPTION"
+\fB\fBclr_power\fR\fR adjusts power and performance in the operating system by setting runtime kernel and device parameters in the proc(5) filesystem\. \fB\fBclr_power\fR\fR operates with built\-in default values\. Values can be added or changed in user\-defined \fBclr\-power\-tweaks\.conf(5)\fR file\.
+.
+.P
+\fB\fBclr_power\fR\fR applies settings and immediately exits after it is started\. It can act as a daemon that enforces settings with the included systemd files\.
+.
+.P
+The program handles server and desktop\-like systems differently and will set values based on whether a system is a server platform or a desktop platform\. Most systems will be assumed a server, and if it can\'t be determined what type of platform the system is, treated as a server platform\. By default, systems with CPU\'s that identify as \fBCore(TM)\fR, \fBCeleron\fR and \fBPentium\fR are treated as desktop systems, and systems with CPU\'s that identify as \fBXeon\fR are treated as server systems\.
+.
+.P
+Tunings applied will vary per system\. To see what tunings are applied, run the program with the \fB\-\-debug\fR option\.
+.
+.SH "OPTIONS"
+\fB\-d\fR, \fB\-\-debug\fR Display debug/verbose output including built\-in values\.
+.
+.P
+\fB\-S\fR, \fB\-\-server\fR Treat the system as a server, and apply server specific tunings\.
+.
+.P
+\fB\-D\fR, \fB\-\-desktop\fR Treat the system as a desktop, and apply desktop specific tunings
+.
+.SH "FILES"
+.
+.IP "\(bu" 4
+\fIclr\-power\.service\fR systemd service unit that executes \fBclr_power\fR\.
+.
+.IP "\(bu" 4
+\fIclr\-power\.timer\fR systemd timer that periodically executes the \fIclr\-power\.service\fR to enforce settings\.
+.
+.IP "\(bu" 4
+\fIclr\-power\-rfkill\.service\fR systemd service that stops bluetooth devices at boot to prevent power drain\.
+.
+.IP "\(bu" 4
+\fI/etc/clr\-power\-tweaks\.conf\fR Optional user\-defined configuration file to override or att values\. See clr\-power\-tweaks\.conf(5) for more information\.
+.
+.IP "" 0
+.
+.SH "BUGS"
+See GitHub Issues: \fIhttps://github\.com/clearlinux/clr\-power\-tweaks/issues\fR
+.
+.SH "SEE ALSO"
+\fBclr\-power\-tweaks\.conf(5)\fR, \fBproc(5)\fR

--- a/man/clr_power.1.md
+++ b/man/clr_power.1.md
@@ -14,13 +14,31 @@ setting runtime kernel and device parameters in the proc(5) filesystem.
 changed in user-defined **clr-power-tweaks.conf(5)** file.
 
 **`clr_power`** applies settings and immediately exits after it is started. It
-can act as a daemon that enforces settings with the included systemd files. 
+can act as a daemon that enforces settings with the included systemd files.
+
+The program handles server and desktop-like systems differently and
+will set values based on whether a system is a server platform or a
+desktop platform.  Most systems will be assumed a server, and if it
+can't be determined what type of platform the system is, treated as
+a server platform. By default, systems with CPU's that identify as
+`Core(TM)`, `Celeron` and `Pentium` are treated as desktop systems,
+and systems with CPU's that identify as `Xeon` are treated as server
+systems.
+
+Tunings applied will vary per system. To see what tunings are applied,
+run the program with the `--debug` option.
 
 
 ## OPTIONS
 
 `-d`, `--debug`
   Display debug/verbose output including built-in values.
+
+`-S`, `--server`
+  Treat the system as a server, and apply server specific tunings.
+
+`-D`, `--desktop`
+  Treat the system as a desktop, and apply desktop specific tunings
 
 
 ## FILES

--- a/src/data.h
+++ b/src/data.h
@@ -25,92 +25,107 @@
 
 #pragma once
 
+/*
+ * For settings, the `where` field should normally be '0' - assume server
+ * If you need to specify a setting for desktop only, use '-1'.
+ * For servers, prefer '0' but use '1' if there's a desktop-alternate value.
+ * You shouldn't have 2 entries where '0' is used as a value for `where`.
+ */
+
 struct write_struct {
 	char *pathglob;
 	char *string;
+	int where; // -1 client, 0 neutral (assume server), 1 server only
 };
 
 struct write_struct write_list[] = {
 	// synchronous dirty ratio --> 50%
-	{"/proc/sys/vm/dirty_ratio", "50"},
-	{"/proc/sys/kernel/unprivileged_bpf_disabled", "1"},
+	{"/proc/sys/vm/dirty_ratio", "50", 0},
+	{"/proc/sys/kernel/unprivileged_bpf_disabled", "1", 0},
 
 	// start IO at 5% not 10%... start IO a little earlier asynchronously, since memory sizes are bigger now
-	{"/proc/sys/vm/dirty_background_ratio", "5"},
+	{"/proc/sys/vm/dirty_background_ratio", "5", 0},
 
 	// 15 seconds before the VM starts writeback, allowing the FS to deal with this better
-	{"/proc/sys/vm/dirty_writeback_centisecs", "1500"},
-	{"/proc/sys/vm/swappiness", "10"},
+	{"/proc/sys/vm/dirty_writeback_centisecs", "1500", 0},
+	{"/proc/sys/vm/swappiness", "10", 0},
 	{"/sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs", "30000"},
-	{"/sys/devices/virtual/graphics/fbcon/cursor_blink", "0"},
-	{"/sys/kernel/rcu_expedited", "0"},
-	{"/proc/sys/vm/mmap_min_addr", "65536"},
+	{"/sys/devices/virtual/graphics/fbcon/cursor_blink", "0", 0},
+	{"/sys/kernel/rcu_expedited", "0", 0},
+	{"/proc/sys/vm/mmap_min_addr", "65536", 0},
 
 	// oom less
-	{"/proc/sys/vm/extfrag_threshold", "100"},
-	{"/sys/kernel/mm/ksm/sleep_millisecs", "4000"},
+	{"/proc/sys/vm/extfrag_threshold", "100", 0},
+	{"/sys/kernel/mm/ksm/sleep_millisecs", "4000", 0},
 
 	// w /sys/kernel/mm/ksm/run - - - - 1
-	{"/sys/kernel/mm/ksm/pages_to_scan", "1000"},
-	{"/proc/sys/net/core/rmem_max", "1703936"},
-	{"/proc/sys/net/core/wmem_max", "1703936"},
-	{"/proc/sys/net/core/somaxconn", "512"},
+	{"/sys/kernel/mm/ksm/pages_to_scan", "1000", 0},
+	{"/proc/sys/net/core/rmem_max", "1703936", 0},
+	{"/proc/sys/net/core/wmem_max", "1703936", 0},
+	{"/proc/sys/net/core/somaxconn", "512", 0},
 
 	// This tuneable decides the minimum time a task will be be allowed to
 	// run on CPU before being pre-empted out
-	{"/proc/sys/kernel/sched_min_granularity_ns", "2250000"},
-	{"/proc/sys/kernel/sched_migration_cost_ns", "50000"},
+	{"/proc/sys/kernel/sched_min_granularity_ns", "2250000", 0},
+	{"/proc/sys/kernel/sched_migration_cost_ns", "50000", 0},
 
 	// Ability of tasks being woken to preempt the current task
-	{"/proc/sys/kernel/sched_wakeup_granularity_ns", "15000000"},
+	{"/proc/sys/kernel/sched_wakeup_granularity_ns", "15000000", 0},
 
 	// audio pm
-	{"/sys/module/snd_hda_intel/parameters/power_save", "1"},
+	{"/sys/module/snd_hda_intel/parameters/power_save", "1", 0},
 
 	// P state stuff
-	{"/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor", "performance"},
+	{"/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor", "performance", 0},
 
 	// we want at least half performance, this helps us in race-to-halt and
 	// to give us reasonable responses
-	{"/sys/devices/system/cpu/intel_pstate/min_perf_pct", "50"},
-	{"/proc/sys/net/core/default_qdisc", "fq"},
+	{"/sys/devices/system/cpu/intel_pstate/min_perf_pct", "50", 0},
+	{"/proc/sys/net/core/default_qdisc", "fq", 0},
 
 	// Disable acceptance of all ICMP redirected packets on all interfaces.
-	{"/proc/sys/net/ipv4/conf/all/accept_redirects", "0"},
-	{"/proc/sys/net/ipv6/conf/all/accept_redirects", "0"},
-	{"/proc/sys/net/ipv4/conf/default/accept_redirects", "0"},
-	{"/proc/sys/net/ipv6/conf/default/accept_redirects", "0"},
+	{"/proc/sys/net/ipv4/conf/all/accept_redirects", "0", 0},
+	{"/proc/sys/net/ipv6/conf/all/accept_redirects", "0", 0},
+	{"/proc/sys/net/ipv4/conf/default/accept_redirects", "0", 0},
+	{"/proc/sys/net/ipv6/conf/default/accept_redirects", "0", 0},
 
 	// Disables sending of all IPv4 ICMP redirected packets on all interfaces.
-	{"/proc/sys/net/ipv4/conf/all/send_redirects", "0"},
-	{"/proc/sys/net/ipv4/conf/default/send_redirects", "0"},
+	{"/proc/sys/net/ipv4/conf/all/send_redirects", "0", 0},
+	{"/proc/sys/net/ipv4/conf/default/send_redirects", "0", 0},
 
 	// Disables acceptance of secure ICMP redirected packets on all interfaces.
-	{"/proc/sys/net/ipv4/conf/all/secure_redirects", "0"},
-	{"/proc/sys/net/ipv4/conf/default/secure_redirects", "0"},
+	{"/proc/sys/net/ipv4/conf/all/secure_redirects", "0", 0},
+	{"/proc/sys/net/ipv4/conf/default/secure_redirects", "0", 0},
 
 	// SATA link power management
-	{"/sys/class/scsi_host/*/link_power_management_policy", "med_power_with_dipm"},
+	{"/sys/class/scsi_host/*/link_power_management_policy", "med_power_with_dipm", 0},
 
 	// Performance tuning for SATA and NVME storage
-	{"/sys/block/sd*/queue/scheduler", "bfq"},
-	{"/sys/block/sd*/queue/nr_requests", "1024"},
-	{"/sys/block/sd*/queue/read_ahead_kb", "1024"},
-	{"/sys/block/sd*/queue/add_random", "1"},
-	{"/sys/block/nvme*/queue/scheduler", "mq-deadline"},
-	{"/sys/block/nvme*/queue/nr_requests", "2048"},
-	{"/sys/block/nvme*/queue/read_ahead_kb", "256"},
-	{"/sys/block/nvme*/queue/add_random", "1"},
+	{"/sys/block/sd*/queue/scheduler", "bfq", 0},
+	{"/sys/block/sd*/queue/nr_requests", "1024", 0},
+	{"/sys/block/sd*/queue/read_ahead_kb", "1024", 0},
+	{"/sys/block/sd*/queue/add_random", "1", 0},
+
+	// For server, prefer mq-deadline to max throughput
+	{"/sys/block/nvme*/queue/scheduler", "mq-deadline", 1},
+
+	// For desktop, prefer bfq low_latency
+	{"/sys/block/nvme*/queue/scheduler", "bfq", -1},
+	{"/sys/block/nvme*/queue/iosched/low_latency", "1", -1},
+
+	{"/sys/block/nvme*/queue/nr_requests", "2048", 0},
+	{"/sys/block/nvme*/queue/read_ahead_kb", "256", 0},
+	{"/sys/block/nvme*/queue/add_random", "1", 0},
 
 	// Enable turbo mode max
-	{"/proc/sys/kernel/sched_itmt_enabled", "1"},
+	{"/proc/sys/kernel/sched_itmt_enabled", "1", 0},
 
 	// Reload the microcode at boot
-	{"/sys/devices/system/cpu/microcode/reload", "1"},
+	{"/sys/devices/system/cpu/microcode/reload", "1", 0},
 
-	{"/proc/sys/kernel/nmi_watchdog", "0"},
-	{"/sys/block/{sd,mmc,nvme}*/queue/iosched/slice_idle", "0"},
+	{"/proc/sys/kernel/nmi_watchdog", "0", 0},
+	{"/sys/block/{sd,mmc,nvme, 0}*/queue/iosched/slice_idle", "0"},
 
 	// End of list.
-	{NULL, NULL}
+	{NULL, NULL, 0}
 };

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,8 @@ const char args_doc[] = "";
 
 static struct argp_option options[] = {
 	{ "debug", 'd', 0, OPTION_ARG_OPTIONAL, "Display debug/verbose output" },
+	{ "server", 'S', 0, OPTION_ARG_OPTIONAL, "Treat system as a server platform" },
+	{ "desktop", 'D', 0, OPTION_ARG_OPTIONAL, "Treat system as a desktop platform" },
 	{ 0 },
 };
 
@@ -58,6 +60,7 @@ struct arguments
 {
 	char *args[1];
 	bool debug;
+	int server_desktop;
 };
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state)
@@ -67,6 +70,12 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 	switch (key) {
 	case 'd':
 		arguments->debug = true;
+		break;
+	case 'S':
+		arguments->server_desktop = 1;
+		break;
+	case 'D':
+		arguments->server_desktop = -1;
 		break;
 	case ARGP_KEY_ARG:
 		if (state->arg_num > 0)
@@ -88,6 +97,8 @@ int main(int argc, char **argv)
 	int status = 0;
 
 	arguments.debug = false;
+	arguments.server_desktop = is_server();
+
 	argp_parse (&argp, argc, argv, 0, 0, &arguments);
 
 	lib_init(arguments.debug);
@@ -126,8 +137,15 @@ int main(int argc, char **argv)
 
 	/* system tweaks */
 	for (int i = 0; write_list[i].pathglob != 0; i++) {
-		status |= write_string_to_files(write_list[i].pathglob,
-				write_list[i].string);
+		/*
+		 * If it's a server, or we don't know, apply generic settings as well as server ones.
+		 * If it's a desktop, apply only desktop settings
+		 */
+		if (((arguments.server_desktop >= 0) && (write_list[i].where >= 0)) ||
+		    ((arguments.server_desktop == -1) && (write_list[i].where == -1))) {
+			status |= write_string_to_files(write_list[i].pathglob,
+					write_list[i].string);
+		}
 	}
 
 //	usleep(150000);

--- a/src/server.c
+++ b/src/server.c
@@ -43,7 +43,7 @@ int is_server(void)
 	char buffer[8192];
 	if (__builtin_cpu_is("intel") <= 0)
 		return 0;
-	
+
 	file = fopen("/proc/cpuinfo", "r");
 	if (!file)
 		return 0;
@@ -55,9 +55,15 @@ int is_server(void)
 			break;
 		if (strstr(buffer, "model name")) {
 			if (strstr(buffer, "Xeon"))
-				ret = 1;		
-			if (strstr(buffer, "Core(TM)"))
-				ret = -1;		
+				ret = 1;
+			else if ((strstr(buffer, "Core(TM)")) ||
+			    (strstr(buffer, "Celeron")) ||
+			    (strstr(buffer, "Pentium")))
+				ret = -1;
+			/*
+			 * Atom - neutral for now, some Atom SoC's are client, but there are
+			 * also Atom based servers.
+			 */
 		}
 	}
 	fclose(file);


### PR DESCRIPTION
We introduce a simple flag to tell whether files are specific
to server, or desktop, or neutral (assumed server).

The default is to tune for servers. If we don't know what a system
is, we'll treat it like a server for now.

You can tell it to tune for desktop by adding `desktop` as a startup
flag on the command line. It will autodetect Intel desktop client
systems by model name, and treats Core(TM), Atom, Celeron and Pentium
named CPU's as desktop systems.

Overrides continue to work as normal.

As a concept illustration, we set the NVME queue scheduler algorithm
to BFQ low latency for desktops. All other settings remain the same.