### PR TITLE
disable sched_autogroup_enabled option on Server

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -72,6 +72,11 @@ struct write_struct write_list[] = {
 	// Ability of tasks being woken to preempt the current task
 	{"/proc/sys/kernel/sched_wakeup_granularity_ns", "15000000", 0},
 
+	// sched_autogroup would improve interactive desktop performance in the face of
+	// multi‐ process, CPU-intensive workloads. Whereas it would harm performance,
+	// thus disable it on Server
+	{"/proc/sys/kernel/sched_autogroup_enabled", "0", 1},
+
 	// audio pm
 	{"/sys/module/snd_hda_intel/parameters/power_save", "1", 0},
 


### PR DESCRIPTION
Kernel option “/proc/sys/kernel/sched_autogroup_enabled” is a tradeoff. It would improve interactive desktop performance in the face of multi-process, CPU-intensive workloads such as building the Linux kernel with large numbers of parallel build processes (i.e., the make(1)-j  flag), whereas it would also brings some downsides and heavily impact performance of some workloads, such as stress-ng context switching benchmark.

As this option mainly improve the interactiveness for desktop, we can disable this option at least on Server to improve performance of Server. A pair of comprehensive phoronix tests are run on Server to compare the influence of enabling and disabling sched_autogroup_enabled option. 

Here are the detailed test results, disabling sched_autogroup_enabled shows better overall performance on Server.


Comparing with enabling sched_autogroup,

1.	disabling sched_autogroup wins 87.8% indicators (253/288).
2.	disabling sched_autogroup shows better Geomean.
a.	Overall Geomean, 1 -> 1.0116 
b.	Disk Geomean, 1 -> 1.0201
c.	Memory Geomean, 1 -> 0.9948
d.	Misc Geomean, 1 -> 0.9988
e.	Network Geomean, 1 -> 1.1985
f.	Processor Geomean, 1 -> 1.0054
g.	System Geomean, 1 -> 1.0185
3.	disabling sched_autogroup brings
a.	less 5% improvement - 19.4% 
b.	5% ~ 10% improvement - 4.2% 
c.	>10% improvement - 3.5% 
d.	less 5% regression - 11.1%
e.	5% ~ 10% regression - 0.3%
f.	>10% regression - 0.7%
g.	flat - 60.8%

BTW, we also looks this option is disabled by default on Debian and Centos.
